### PR TITLE
fix(MegaprokerSection): update image URL retrieval logic for better h…

### DIFF
--- a/src/pages/Megaproker/section/Megaproker.jsx
+++ b/src/pages/Megaproker/section/Megaproker.jsx
@@ -15,15 +15,15 @@ const MegaprokerSection = ({ megaprokers, index, baseUrl }) => {
             <BGKiri 
               className="w-full h-full object-cover" 
               imageUrl={`${baseUrl}/storage/${
-              megaprokers.images?.find(img => img.megaproker_id === megaprokers.id)?.url || ''
-              }`} 
+                (megaprokers.images && megaprokers.images.length > 0) ? megaprokers.images[0].url : ''
+                }`}
             />
           ) : (
             <BGKanan 
               className="w-full h-full object-cover" 
               imageUrl={`${baseUrl}/storage/${
-              megaprokers.images?.find(img => img.megaproker_id === megaprokers.id)?.url || ''
-              }`}
+                (megaprokers.images && megaprokers.images.length > 0) ? megaprokers.images[0].url : ''
+                }`}
             />
           )}
         </div>


### PR DESCRIPTION
This pull request includes a small change to the `MegaprokerSection` component in the `src/pages/Megaproker/section/Megaproker.jsx` file. The change simplifies the logic for determining the image URL to use for the `BGKiri` and `BGKanan` components.

* [`src/pages/Megaproker/section/Megaproker.jsx`](diffhunk://#diff-c45c16cc221af1269d7a4acd59eeaa2ef7425cc0c3dd481b7c637a78c4532ce4L18-R25): Updated the logic to use the first image URL from the `megaprokers.images` array if it exists, instead of finding an image by `megaproker_id`.…andling of empty states