### PR TITLE
Landing page/riset

### DIFF
--- a/src/pages/Megaproker/section/Megaproker.jsx
+++ b/src/pages/Megaproker/section/Megaproker.jsx
@@ -34,7 +34,7 @@ const MegaprokerSection = ({ megaprokers, index, baseUrl }) => {
             <img 
               src={`${baseUrl}/storage/${megaprokers.logo}`}
               alt={megaprokers.name} 
-              className="w-[280px] md:w-[400px] lg:w-[450px] h-auto pb-6 rounded-2xl"
+              className="w-[280px] md:w-[400px] lg:w-[450px] h-auto pb-6"
             />
           </div>
 

--- a/src/pages/Riset/section/RisetCard.jsx
+++ b/src/pages/Riset/section/RisetCard.jsx
@@ -3,8 +3,7 @@ import MotionReveal from '@/components/common/MotionReveal';
 import ReadMoreButton from "@/components/common/ReadMore";
 
 const Card = ({ research, baseUrl }) => (
- <MotionReveal animation="fade-up" delay={0.1}>
-  <div className="shadow-card rounded-2xl flex flex-col bg-white w-[177px] h-[390px] sm:w-[250px] sm:h-[460px] md:w-[250px] md:h-[460px] lg:w-[370px] lg:h-[620px]">
+  <div className="shadow-card rounded-2xl flex flex-col bg-white w-[177px] h-[390px] sm:w-[250px] sm:h-[470px] lg:w-[370px] lg:h-[650px] gap-2">
     <div className="">
       <img 
         src={`${baseUrl}/storage/${research.image}`}
@@ -12,28 +11,29 @@ const Card = ({ research, baseUrl }) => (
         className="w-full h-[220px] sm:h-[300px] md:h-[300px] lg:h-[450px] rounded-2xl shadow-card"
       />
     </div>
-    <div className="p-2 lg:p-4">
-      <div className="justify-evenly text-start">
-        <h1 className="font-medium text-[16px] lg:text-xl">{research.title}</h1>
+    <div className="justify-evenly p-2 lg:p-4">
+      <div className="h-15 lg:h-22 text-start">
+        <h1 className="font-medium text-[13px] lg:text-xl">{research.title}</h1>
         <p className="font-light text-[15px] lg:text-xl ">{research.year}</p>
       </div>
-      <div className="place-items-start pt-3">
+      <div className="place-items-start pt-10 lg:py-6">
         <ReadMoreButton to={research.link}/>
       </div>
     </div>
   </div>
- </MotionReveal>
 );
 
 const RisCard = ({ data, baseUrl }) => {
   return (
       <div className="justify-items-center mx-auto max-w-6xl gap-y-4 gap-8 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-2 xl:grid-cols-3 lg:gap-[50px] lg:pt-[70px]">
-        {data.research.map((research) => (
-          <Card 
-            key={research.id}
-            research={research} 
-            baseUrl={baseUrl}
-         />
+        {data.research.map((research, index) => (
+          <MotionReveal key={research.id} animation="fade-up" delay={0.1 + (index * 0.05)}>
+            <Card 
+              key={research.id}
+              research={research} 
+              baseUrl={baseUrl}
+            />
+          </MotionReveal>
        ))}
       </div>
   );

--- a/src/pages/Riset/section/RisetCard.jsx
+++ b/src/pages/Riset/section/RisetCard.jsx
@@ -2,8 +2,19 @@ import React from "react";
 import MotionReveal from '@/components/common/MotionReveal';
 import ReadMoreButton from "@/components/common/ReadMore";
 
-const Card = ({ research, baseUrl }) => (
-  <div className="shadow-card rounded-2xl flex flex-col bg-white w-[177px] h-[390px] sm:w-[250px] sm:h-[470px] lg:w-[370px] lg:h-[650px] gap-2">
+const Card = ({ research, baseUrl }) => {
+
+  // Create a function to truncate text
+  const truncateText = (text, maxLength) => {
+    if (!text) return '';
+    return text.length > maxLength ? text.substring(0, maxLength) + '...' : text;
+  };
+
+  const title = research.title || '';
+  const truncatedTitle = truncateText(title, 61);
+
+  return (
+  <div className="shadow-card rounded-2xl flex flex-col bg-white w-[177px] h-[380px] sm:w-[250px] sm:h-[460px] lg:w-[370px] lg:h-[650px] gap-2">
     <div className="">
       <img 
         src={`${baseUrl}/storage/${research.image}`}
@@ -13,15 +24,19 @@ const Card = ({ research, baseUrl }) => (
     </div>
     <div className="justify-evenly p-2 lg:p-4">
       <div className="h-15 lg:h-22 text-start">
-        <h1 className="font-medium text-[13px] lg:text-xl">{research.title}</h1>
+        <h1 className="font-medium text-[13px] lg:text-xl">
+          <span className="lg:hidden">{truncatedTitle}</span>
+          <span className="hidden lg:block">{research.title}</span>
+        </h1>
         <p className="font-light text-[15px] lg:text-xl ">{research.year}</p>
       </div>
-      <div className="place-items-start pt-10 lg:py-6">
+      <div className="place-items-start pt-8 lg:py-9">
         <ReadMoreButton to={research.link}/>
       </div>
     </div>
   </div>
-);
+  );
+};
 
 const RisCard = ({ data, baseUrl }) => {
   return (

--- a/src/pages/Syntax/section/SyntaxCard.jsx
+++ b/src/pages/Syntax/section/SyntaxCard.jsx
@@ -4,7 +4,7 @@ import MotionReveal from '@/components/common/MotionReveal';
 
 const Card = ({ syntaxes, baseUrl }) => (
   <MotionReveal animation="fade-up" delay={0.1}>
-    <div className="shadow-card rounded-2xl flex flex-col bg-white w-[170px] h-[360px] sm:w-[230px] sm:h-[420px] md:w-[230px] md:h-[430px] lg:w-[380px] lg:h-[600px] xl:w-[330px] ">
+    <div className="shadow-card rounded-2xl flex flex-col gap-2 bg-white w-[170px] h-[360px] sm:w-[230px] sm:h-[420px] md:w-[230px] md:h-[430px] lg:w-[380px] lg:h-[600px] xl:w-[330px] ">
       <div className="">
         <img 
           src={`${baseUrl}/storage/${syntaxes.image}`}
@@ -14,7 +14,7 @@ const Card = ({ syntaxes, baseUrl }) => (
       </div>
       <div className="p-2 lg:p-4">
         <div className="justify-evenly text-start">
-          <h1 className="font-medium text-[16px] md:text-xl">{syntaxes.title}</h1>
+          <h1 className="font-semibold text-[18px] md:text-xl">{syntaxes.title}</h1>
           <p className="font-light text-[15px] md:text-xl ">{syntaxes.year}</p>
         </div>
         <div className="place-items-start pt-4">

--- a/src/pages/Syntax/section/SyntaxCard.jsx
+++ b/src/pages/Syntax/section/SyntaxCard.jsx
@@ -28,12 +28,14 @@ const Card = ({ syntaxes, baseUrl }) => (
 const SynCard = ({ data, baseUrl }) => {
   return (
       <div className="justify-items-center mx-auto max-w-6xl gap-y-4 gap-8 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-2 xl:grid-cols-3 lg:gap-[50px] lg:pt-[70px]">
-        {data.syntaxes.map((syntaxes) => (
-          <Card 
-            key={syntaxes.id}
-            syntaxes={syntaxes} 
-            baseUrl={baseUrl}
-          />
+        {data.syntaxes.map((syntaxes, index) => (
+          <MotionReveal key={syntaxes.id} animation="fade-up" delay={0.1 + (index * 0.05)}>
+            <Card 
+              key={syntaxes.id}
+              syntaxes={syntaxes} 
+              baseUrl={baseUrl}
+            />
+          </MotionReveal>
         ))}
       </div>
   );


### PR DESCRIPTION
This pull request introduces several updates to improve the user interface and functionality of components across multiple sections of the application. Key changes include styling adjustments, the addition of animations, and the implementation of a text truncation feature for better responsiveness and visual consistency.

### Styling and Layout Adjustments:
- Removed the `rounded-2xl` class from the `img` tag in the `MegaprokerSection` component to simplify the visual design. (`src/pages/Megaproker/section/Megaproker.jsx`, [src/pages/Megaproker/section/Megaproker.jsxL37-R37](diffhunk://#diff-c45c16cc221af1269d7a4acd59eeaa2ef7425cc0c3dd481b7c637a78c4532ce4L37-R37))
- Added a `gap-2` class to the `Card` component in the `SyntaxCard` section for better spacing between elements. (`src/pages/Syntax/section/SyntaxCard.jsx`, [src/pages/Syntax/section/SyntaxCard.jsxL7-R7](diffhunk://#diff-8b4af6df8da9a8b59fea2059ad41a8f6fb6e6cdb99781a904e4f29c396b1681cL7-R7))
- Updated the font weight of the title in the `SyntaxCard` component to `font-semibold` for improved emphasis. (`src/pages/Syntax/section/SyntaxCard.jsx`, [src/pages/Syntax/section/SyntaxCard.jsxL17-R17](diffhunk://#diff-8b4af6df8da9a8b59fea2059ad41a8f6fb6e6cdb99781a904e4f29c396b1681cL17-R17))

### Functional Enhancements:
- Implemented a text truncation function in the `RisetCard` component to limit the title length on smaller screens, ensuring better responsiveness. (`src/pages/Riset/section/RisetCard.jsx`, [src/pages/Riset/section/RisetCard.jsxL5-R51](diffhunk://#diff-bea8c7ef379b0bca8899c74c4dcebc49cbd6c4d965fe659ad0e2cd0df945f3d4L5-R51))

### Animation Improvements:
- Added unique animation delays to the `MotionReveal` component in both the `RisetCard` and `SyntaxCard` sections to create a staggered animation effect for better visual appeal. (`src/pages/Riset/section/RisetCard.jsx`, [[1]](diffhunk://#diff-bea8c7ef379b0bca8899c74c4dcebc49cbd6c4d965fe659ad0e2cd0df945f3d4L5-R51); `src/pages/Syntax/section/SyntaxCard.jsx`, [[2]](diffhunk://#diff-8b4af6df8da9a8b59fea2059ad41a8f6fb6e6cdb99781a904e4f29c396b1681cL31-R38)