### PR TITLE
Feat: added community portofolios

### DIFF
--- a/src/hooks/useAPI.js
+++ b/src/hooks/useAPI.js
@@ -7,7 +7,7 @@ import axios from 'axios';
  * @param {string} baseUrl - Base URL API
  * @returns {Object} - Data, loading state, dan error state
  */
-export const useFetchData = (endpoint, baseUrl) => {
+export const useFetchData = (endpoint, baseUrl) => {  
   const [state, setState] = useState({
     data: null,
     loading: false,

--- a/src/pages/Departemen/sections/Staff.jsx
+++ b/src/pages/Departemen/sections/Staff.jsx
@@ -127,7 +127,7 @@ const StaffSection = ({ staff, baseUrl }) => {
           {/* Regular Staff (2 columns grid) */}
           <div className="grid grid-cols-2 gap-y-8 justify-items-center">
             {regularStaff.map((staffMember, index) => (
-              <div key={staffMember.id || `staff-mobile-${index}`}>
+              <div key={staffMember.id}>
                 <StaffCard staff={staffMember} baseUrl={baseUrl} />
               </div>
             ))}

--- a/src/pages/Komunitas/index.jsx
+++ b/src/pages/Komunitas/index.jsx
@@ -14,6 +14,7 @@ import NotFound from '../NotFound';
 
 // Import section
 import DokumKomun from './section/dokumKomun';
+import PortoKomun from './section/PortoKomun'
 
 const Komunitas = () => {
   const baseUrl = import.meta.env.VITE_API_BASE_URL;
@@ -100,6 +101,13 @@ const Komunitas = () => {
             ...img,      
             url: `${baseUrl}/storage/${img.url}`
             }))} />
+        </section>
+      </MotionReveal>
+      
+      <MotionReveal animation="fade-up" delay={0.2}>
+        <section className="px-4 flex flex-col mt-[200px] items-center">
+          <SectionHeader title="PORTOFOLIO KOMUNITAS" altText="Garis Dokumentasi" />
+          <PortoKomun slug={slug} baseUrl={baseUrl}/>
         </section>
       </MotionReveal>
 

--- a/src/pages/Komunitas/index.jsx
+++ b/src/pages/Komunitas/index.jsx
@@ -13,7 +13,7 @@ import MotionReveal from '@/components/common/MotionReveal';
 import NotFound from '../NotFound';
 
 // Import section
-import DokumKomun from './section/dokumKomun';
+import DokumKomun from './section/DokumKomun';
 import PortoKomun from './section/PortoKomun'
 
 const Komunitas = () => {

--- a/src/pages/Komunitas/section/PortoKomun.jsx
+++ b/src/pages/Komunitas/section/PortoKomun.jsx
@@ -1,0 +1,101 @@
+import { useFetchData } from '@/hooks/useAPI';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
+import MotionReveal from '@/components/common/MotionReveal';
+import { FaGithub, FaExternalLinkAlt } from 'react-icons/fa'; // Impor ikon
+
+const PortoKomun = ({ slug, baseUrl }) => {
+  const { data, loading, error } = useFetchData(`communities/${slug}/portofolio`, baseUrl);
+
+  if (loading) {
+    return <LoadingSpinner variant="section" size="medium" message="Memuat portofolio..." />;
+  }
+
+  if (error) {
+    return <p className="text-center text-red-500">Gagal memuat portofolio. Silakan coba lagi nanti.</p>;
+  }
+
+  if (!data || !data.communityPortofolios || !Array.isArray(data.communityPortofolios) || data.communityPortofolios.length === 0) {
+    return <p className="text-center text-gray-500">Belum ada portofolio untuk komunitas ini.</p>;
+  }
+
+  return (
+    <MotionReveal animation="fade-up" delay={0.1}>
+      <div className="container mx-auto px-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 md:gap-8">
+          {data.communityPortofolios.map(porto => (
+            <div
+              key={porto.id}
+              className="bg-white rounded-xl shadow-card overflow-hidden hover:shadow-lg transition-all duration-300 hover:translate-y-[-5px] h-full flex flex-col"
+            >
+              {/* Image dengan link dan overlay */}
+              <a href={porto.link || '#'} target="_blank" rel="noopener noreferrer" className="block">
+                <div className="w-full h-[220px] overflow-hidden relative group">
+                  <img
+                    src={`${baseUrl}/storage/${porto.image}`}
+                    alt={porto.name}
+                    className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
+                    onError={(e) => {
+                      e.target.onerror = null;
+                      e.target.src = '/images/placeholder-image.png';
+                    }}
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-end">
+                    <div className="p-4 w-full text-white">
+                      <h3 className="font-bold text-lg">{porto.name}</h3>
+                    </div>
+                  </div>
+                </div>
+              </a>
+
+              {/* Konten */}
+              <div className="p-5 flex-1 flex flex-col">
+                <h3 className="font-bold text-lg mb-2 text-primary-dark group-hover:text-primary transition-colors">
+                  {porto.name}
+                </h3>
+
+                {porto.description && (
+                  <p className="text-sm text-gray-600 mb-4 line-clamp-3 flex-1">
+                    {porto.description}
+                  </p>
+                )}
+
+                {porto.author && (
+                  <div className="flex items-center text-xs text-gray-500 mb-4">
+                    <span className="font-medium mr-1">Oleh:</span> {porto.author}
+                  </div>
+                )}
+
+                {/* Actions di bagian bawah */}
+                {porto.link && (
+                  <div className="mt-auto pt-3 border-t border-gray-100 flex justify-end">
+                    <a
+                      href={porto.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-2 text-sm font-medium text-primary-dark hover:text-primary transition"
+                      aria-label={`Lihat proyek ${porto.name}`}
+                    >
+                      {porto.link.includes('github.com') ? (
+                        <>
+                          <FaGithub size={16} />
+                          <span>GitHub</span>
+                        </>
+                      ) : (
+                        <>
+                          <FaExternalLinkAlt size={14} />
+                          <span>Lihat Proyek</span>
+                        </>
+                      )}
+                    </a>
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </MotionReveal>
+  );
+}
+
+export default PortoKomun;


### PR DESCRIPTION
This pull request introduces a new "Community Portfolio" section to the `Komunitas` page, improves code readability, and fixes a minor issue in the `Staff` section. The most significant changes include adding the `PortoKomun` component, integrating it into the `Komunitas` page, and refining the key assignment in the `Staff` section.

### New Feature: Community Portfolio Section
* Added a new `PortoKomun` component to display a portfolio of community projects. This component fetches data via the `useFetchData` hook, handles loading and error states, and renders project cards with details like name, description, author, and links. (`src/pages/Komunitas/section/PortoKomun.jsx`)
* Integrated the `PortoKomun` component into the `Komunitas` page with a new section titled "PORTOFOLIO KOMUNITAS." This section uses `MotionReveal` for animation and passes the `slug` and `baseUrl` props to `PortoKomun`. (`src/pages/Komunitas/index.jsx`)

### Code Improvements
* Imported the `PortoKomun` component into the `Komunitas` page to enable its usage. (`src/pages/Komunitas/index.jsx`)

### Bug Fix
* Updated the key assignment in the `Staff` section to use only `staffMember.id`, removing the fallback to a string-based key. This ensures unique and consistent keys for React elements. (`src/pages/Departemen/sections/Staff.jsx`)