### PR TITLE
update react, vulnerable cik

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "framer-motion": "^12.6.3",
     "lucide-react": "^0.482.0",
     "pnpm": "^10.5.2",
-    "react": "^19.0.0",
+    "react": "^19.2.3",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,31 +22,31 @@ importers:
         version: 0.25.0
       framer-motion:
         specifier: ^12.6.3
-        version: 12.6.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 12.6.3(react-dom@19.0.0(react@19.2.3))(react@19.2.3)
       lucide-react:
         specifier: ^0.482.0
-        version: 0.482.0(react@19.0.0)
+        version: 0.482.0(react@19.2.3)
       pnpm:
         specifier: ^10.5.2
         version: 10.5.2
       react:
-        specifier: ^19.0.0
-        version: 19.0.0
+        specifier: ^19.2.3
+        version: 19.2.3
       react-dom:
         specifier: ^19.0.0
-        version: 19.0.0(react@19.0.0)
+        version: 19.0.0(react@19.2.3)
       react-icons:
         specifier: ^5.5.0
-        version: 5.5.0(react@19.0.0)
+        version: 5.5.0(react@19.2.3)
       react-router-dom:
         specifier: ^7.3.0
-        version: 7.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 7.4.0(react-dom@19.0.0(react@19.2.3))(react@19.2.3)
       react-spinner:
         specifier: ^0.2.7
-        version: 0.2.7(react@19.0.0)
+        version: 0.2.7(react@19.2.3)
       react-spinners:
         specifier: ^0.15.0
-        version: 0.15.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 0.15.0(react-dom@19.0.0(react@19.2.3))(react@19.2.3)
       swiper:
         specifier: ^11.2.6
         version: 11.2.6
@@ -868,8 +868,8 @@ packages:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  react@19.0.0:
-    resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
+  react@19.2.3:
+    resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
   rollup@4.34.9:
@@ -1446,14 +1446,14 @@ snapshots:
       es-set-tostringtag: 2.1.0
       mime-types: 2.1.35
 
-  framer-motion@12.6.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  framer-motion@12.6.3(react-dom@19.0.0(react@19.2.3))(react@19.2.3):
     dependencies:
       motion-dom: 12.6.3
       motion-utils: 12.6.3
       tslib: 2.8.1
     optionalDependencies:
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
+      react: 19.2.3
+      react-dom: 19.0.0(react@19.2.3)
 
   fsevents@2.3.3:
     optional: true
@@ -1553,9 +1553,9 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@0.482.0(react@19.0.0):
+  lucide-react@0.482.0(react@19.2.3):
     dependencies:
-      react: 19.0.0
+      react: 19.2.3
 
   math-intrinsics@1.1.0: {}
 
@@ -1589,43 +1589,43 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
-  react-dom@19.0.0(react@19.0.0):
+  react-dom@19.0.0(react@19.2.3):
     dependencies:
-      react: 19.0.0
+      react: 19.2.3
       scheduler: 0.25.0
 
-  react-icons@5.5.0(react@19.0.0):
+  react-icons@5.5.0(react@19.2.3):
     dependencies:
-      react: 19.0.0
+      react: 19.2.3
 
   react-refresh@0.14.2: {}
 
-  react-router-dom@7.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  react-router-dom@7.4.0(react-dom@19.0.0(react@19.2.3))(react@19.2.3):
     dependencies:
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
-      react-router: 7.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.2.3
+      react-dom: 19.0.0(react@19.2.3)
+      react-router: 7.4.0(react-dom@19.0.0(react@19.2.3))(react@19.2.3)
 
-  react-router@7.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  react-router@7.4.0(react-dom@19.0.0(react@19.2.3))(react@19.2.3):
     dependencies:
       '@types/cookie': 0.6.0
       cookie: 1.0.2
-      react: 19.0.0
+      react: 19.2.3
       set-cookie-parser: 2.7.1
       turbo-stream: 2.4.0
     optionalDependencies:
-      react-dom: 19.0.0(react@19.0.0)
+      react-dom: 19.0.0(react@19.2.3)
 
-  react-spinner@0.2.7(react@19.0.0):
+  react-spinner@0.2.7(react@19.2.3):
     dependencies:
-      react: 19.0.0
+      react: 19.2.3
 
-  react-spinners@0.15.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  react-spinners@0.15.0(react-dom@19.0.0(react@19.2.3))(react@19.2.3):
     dependencies:
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
+      react: 19.2.3
+      react-dom: 19.0.0(react@19.2.3)
 
-  react@19.0.0: {}
+  react@19.2.3: {}
 
   rollup@4.34.9:
     dependencies:


### PR DESCRIPTION
This pull request upgrades the `react` dependency from version 19.0.0 to 19.2.3 across the project. This update affects the main `package.json` as well as all related dependency resolutions in the `pnpm-lock.yaml` file, ensuring that all packages relying on `react` now use the updated version for improved compatibility and potential bug fixes.

**Dependency upgrades:**

* Updated the `react` version in `package.json` from `^19.0.0` to `^19.2.3`.
* Updated all references to `react` and related dependencies (such as `react-dom`, `framer-motion`, `lucide-react`, `react-icons`, `react-router-dom`, `react-spinner`, and `react-spinners`) in `pnpm-lock.yaml` to use version 19.2.3, ensuring consistency across the dependency tree. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL25-R49) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL871-R872) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1449-R1456) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1556-R1558) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1592-R1628)